### PR TITLE
Add socks5 support

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -55,6 +55,18 @@
 			"Rev": "f3960ab1f9664ecc4e27c78af27cc9063d745a43"
 		},
 		{
+			"ImportPath": "github.com/satori/go.uuid",
+			"Rev": "e673fdd4dea8a7334adbbe7f57b7e4b00bdc5502"
+		},
+		{
+			"ImportPath": "golang.org/x/net/proxy",
+			"Rev": "6acef71eb69611914f7a30939ea9f6e194c78172"
+		},
+		{
+			"ImportPath": "golang.org/x/sys/windows",
+			"Rev": "54535356f1d989a6072b0898d9ddc4dd7009dcd3"
+		},
+		{
 			"ImportPath": "gopkg.in/yaml.v2",
 			"Rev": "53feefa2559fb8dfa8d81baad31be332c97d6c77"
 		}

--- a/collector/collector.go
+++ b/collector/collector.go
@@ -1,13 +1,30 @@
 package collector
 
 import (
+	"net/http"
 	"net/url"
+	"os"
+
+	"golang.org/x/net/proxy"
 )
 
 // Collector collects status from Nginx status module.
 type Collector interface {
 	// Collect status from the given url.
 	Collect(u url.URL) (map[string]interface{}, error)
+}
+
+// HTTPClient returns a net/http client that respects proxy settings from the
+// environmnent. Supported environmnent variables:
+// "http_proxy", "https_proxy", "all_proxy", and "no_proxy".
+func HTTPClient() *http.Client {
+	if os.Getenv("all_proxy") != "" {
+		return &http.Client{
+			Transport: &http.Transport{Dial: proxy.FromEnvironment().Dial},
+		}
+	}
+
+	return http.DefaultClient
 }
 
 // Ftoi returns a copy of input map where float values are casted to int values.

--- a/collector/collector_test.go
+++ b/collector/collector_test.go
@@ -1,0 +1,72 @@
+// +build unit
+
+package collector
+
+import (
+	"os"
+	"testing"
+
+	"net"
+	"net/http"
+	"net/http/httptest"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestHTTPClient(t *testing.T) {
+	// It should hit SOCKS5 proxy.
+	p1, _ := net.Listen("tcp", "127.0.0.1:0")
+	defer p1.Close()
+
+	pr1 := false
+	go func() {
+		c, err := p1.Accept()
+		if err != nil {
+			return
+		}
+		defer c.Close()
+
+		pr1 = true
+	}()
+
+	hr1 := false
+	ts1 := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hr1 = true
+	}))
+	defer ts1.Close()
+
+	os.Setenv("all_proxy", "socks5://"+p1.Addr().String())
+	c1 := HTTPClient()
+	c1.Get(ts1.URL)
+	os.Setenv("all_proxy", "")
+
+	assert.Equal(t, pr1, true)
+	assert.Equal(t, hr1, false)
+
+	// It should hit HTTP server directly.
+	p2, _ := net.Listen("tcp", "127.0.0.1:0")
+	defer p2.Close()
+
+	pr2 := false
+	go func() {
+		c, err := p2.Accept()
+		if err != nil {
+			return
+		}
+		defer c.Close()
+
+		pr2 = true
+	}()
+
+	hr2 := false
+	ts2 := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hr2 = true
+	}))
+	defer ts2.Close()
+
+	c2 := HTTPClient()
+	c2.Get(ts2.URL)
+
+	assert.Equal(t, pr2, false)
+	assert.Equal(t, hr2, true)
+}

--- a/collector/integration_test.go
+++ b/collector/integration_test.go
@@ -12,7 +12,7 @@ import (
 
 func TestStubCollectorIntegration(t *testing.T) {
 	// It should report stats of Nginx running inside Docker container.
-	c1 := &StubCollector{}
+	c1 := NewStubCollector()
 	u1, _ := url.Parse("http://nginx-19:8080/status")
 	s1, _ := c1.Collect(*u1)
 
@@ -37,7 +37,7 @@ func TestStubCollectorIntegration(t *testing.T) {
 
 func TestPlusCollectorIntegration(t *testing.T) {
 	// It should report stats of Nginx running on demo.nginx.com.
-	c1 := &PlusCollector{}
+	c1 := NewPlusCollector()
 	u1, _ := url.Parse("http://demo.nginx.com/status")
 	s1, _ := c1.Collect(*u1)
 

--- a/collector/plus.go
+++ b/collector/plus.go
@@ -10,16 +10,17 @@ import (
 
 // PlusCollector is a Collector that collects Nginx Plus status page.
 type PlusCollector struct {
+	http *http.Client
 }
 
 // NewPlusCollector constructs a new PlusCollector.
 func NewPlusCollector() Collector {
-	return &PlusCollector{}
+	return &PlusCollector{http: HTTPClient()}
 }
 
 // Collect Nginx Plus status from given url.
 func (c *PlusCollector) Collect(u url.URL) (map[string]interface{}, error) {
-	res, err := http.Get(u.String())
+	res, err := c.http.Get(u.String())
 	if err != nil {
 		return nil, err
 	}

--- a/collector/plus_test.go
+++ b/collector/plus_test.go
@@ -90,7 +90,7 @@ func TestPlusCollector(t *testing.T) {
 	}))
 	defer ts1.Close()
 
-	c1 := &PlusCollector{}
+	c1 := NewPlusCollector()
 	u1, _ := url.Parse(ts1.URL)
 	s1, _ := c1.Collect(*u1)
 
@@ -123,7 +123,7 @@ func TestPlusCollector(t *testing.T) {
 	}))
 	defer ts2.Close()
 
-	c2 := &PlusCollector{}
+	c2 := NewPlusCollector()
 	u2, _ := url.Parse(ts2.URL)
 	s2, e2 := c2.Collect(*u2)
 
@@ -136,7 +136,7 @@ func TestPlusCollector(t *testing.T) {
 	}))
 	defer ts3.Close()
 
-	c3 := &PlusCollector{}
+	c3 := NewPlusCollector()
 	u3, _ := url.Parse(ts3.URL)
 	s3, e3 := c3.Collect(*u3)
 

--- a/collector/stub.go
+++ b/collector/stub.go
@@ -13,17 +13,21 @@ import (
 
 // StubCollector is a Collector that collects Nginx stub status page.
 type StubCollector struct {
+	http     *http.Client
 	requests int
 }
 
 // NewStubCollector constructs a new StubCollector.
 func NewStubCollector() Collector {
-	return &StubCollector{requests: 0}
+	return &StubCollector{
+		http:     HTTPClient(),
+		requests: 0,
+	}
 }
 
 // Collect Nginx stub status from given url.
 func (c *StubCollector) Collect(u url.URL) (map[string]interface{}, error) {
-	res, err := http.Get(u.String())
+	res, err := c.http.Get(u.String())
 	if err != nil {
 		return nil, err
 	}

--- a/collector/stub_test.go
+++ b/collector/stub_test.go
@@ -23,7 +23,7 @@ func TestStubCollector(t *testing.T) {
 	}))
 	defer ts1.Close()
 
-	c1 := &StubCollector{}
+	c1 := NewStubCollector()
 	u1, _ := url.Parse(ts1.URL)
 	s1, _ := c1.Collect(*u1)
 
@@ -68,7 +68,7 @@ func TestStubCollector(t *testing.T) {
 	}))
 	defer ts2.Close()
 
-	c2 := &StubCollector{}
+	c2 := NewStubCollector()
 	u2, _ := url.Parse(ts2.URL)
 	s2, _ := c2.Collect(*u2)
 
@@ -91,7 +91,7 @@ func TestStubCollector(t *testing.T) {
 	}))
 	defer ts3.Close()
 
-	c3 := &StubCollector{}
+	c3 := NewStubCollector()
 	u3, _ := url.Parse(ts3.URL)
 	s3, _ := c3.Collect(*u3)
 
@@ -114,7 +114,7 @@ func TestStubCollector(t *testing.T) {
 	}))
 	defer ts4.Close()
 
-	c4 := &StubCollector{}
+	c4 := NewStubCollector()
 	u4, _ := url.Parse(ts4.URL)
 	s4, _ := c4.Collect(*u4)
 
@@ -134,7 +134,7 @@ func TestStubCollector(t *testing.T) {
 	}))
 	defer ts5.Close()
 
-	c5 := &StubCollector{}
+	c5 := NewStubCollector()
 	u5, _ := url.Parse(ts5.URL)
 	s5, e5 := c5.Collect(*u5)
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,5 +25,7 @@ nginxbeat:
     - .:/go/src/github.com/mrkschan/nginxbeat/
     - ${GOPATH}/src/github.com/elastic/beats:/go/src/github.com/elastic/beats/
     - ${GOPATH}/src/github.com/stretchr/testify:/go/src/github.com/stretchr/testify/
+    - ${GOPATH}/src/github.com/satori/go.uuid:/go/src/github.com/satori/go.uuid/
+    - ${GOPATH}/src/golang.org/x/net/proxy:/go/src/golang.org/x/net/proxy/
   working_dir: /go/src/github.com/mrkschan/nginxbeat/
   command: make


### PR DESCRIPTION
This patch enables nginxbeat to contact Nginx via HTTP / SOCKS5 proxy. The proxy URL can be specified with `http_proxy`, `https_proxy`, and `all_proxy` environment variables.

Close #42 
